### PR TITLE
Fix sprite path, generate fallback PNG sprite.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,6 +19,7 @@ import imageminGiflossy from "imagemin-giflossy";
 import imageminSvgo from "imagemin-svgo";
 import favicons from "gulp-favicons";
 import svgSprite from "gulp-svg-sprites";
+import raster from "gulp-raster";
 import replace from "gulp-replace";
 import rigger from "gulp-rigger";
 import plumber from "gulp-plumber";
@@ -187,8 +188,10 @@ export const sprites = () => src(paths.src.sprites)
 	.pipe(svgSprite({
 		preview: false,
 		cssFile: "../../../src/styles/components/_sprite.scss",
+		svgPath: "../img/sprites/sprite.svg",
+		pngPath: "../img/sprites/sprite.png",
 		svg: {
-			sprite: "../../../src/img/sprites/sprite.svg"
+			sprite: "sprite.svg"
 		}
 	}))
 	.pipe(dest(paths.build.sprites))
@@ -196,6 +199,11 @@ export const sprites = () => src(paths.src.sprites)
 		"title": "Sprites"
 	}))
 	.on("end", browsersync.reload);
+
+export const svg2png = () => src(`${paths.build.sprites}**/*.svg`)
+	.pipe(raster())
+	.pipe(rename({ extname: '.png'}))
+	.pipe(dest(paths.build.sprites));
 
 export const favs = () => src(paths.src.favicons)
 	.pipe(favicons({
@@ -216,9 +224,9 @@ export const favs = () => src(paths.src.favicons)
 		"title": "Favicons"
 	}));
 
-export const development = series(cleanFiles, sprites, parallel(html, styles, scripts, images, favs),
+export const development = series(cleanFiles, sprites, svg2png, parallel(html, styles, scripts, images, favs),
 	parallel(watchCode, server));
 
-export const prod = series(cleanFiles, sprites, serverConfig, html, styles, scripts, images, favs);
+export const prod = series(cleanFiles, sprites, svg2png, serverConfig, html, styles, scripts, images, favs);
 
 export default development;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"gulp-if": "^2.0.2",
 		"gulp-imagemin": "^5.0.3",
 		"gulp-plumber": "^1.2.0",
+		"gulp-raster": "^0.2.0",
 		"gulp-rename": "^1.2.2",
 		"gulp-replace": "^0.6.1",
 		"gulp-rigger": "^0.5.8",


### PR DESCRIPTION
1. Больше не генерируется лишний спрайт в ```src/img/sprites```.
2. Исправлен путь к спрайту в CSS.
3. Создание PNG спрайта для .no-svg